### PR TITLE
タイトルセレクター関連機能修正

### DIFF
--- a/Classes/Datas/Scene/OpeningSceneData.cpp
+++ b/Classes/Datas/Scene/OpeningSceneData.cpp
@@ -12,22 +12,9 @@
 bool OpeningSceneData::init()
 {
     FUNCLOG
-    string basePath;
-    string jsonPath = ResourcesManager::getInstance()->getCurrentFilePath(Resource::ConfigFiles::PRELOAD_LIST);
-    int length;
-    const rapidjson::Document json = LastSupper::JsonUtils::readJsonCrypted(jsonPath);
-    for (rapidjson::Value::ConstMemberIterator itr = json.MemberBegin(); itr != json.MemberEnd(); itr++)
-    {
-        basePath = ResourcesManager::getInstance()->getCurrentPath() + "/";
-        basePath += itr->name.GetString();
-        basePath += "/";
-        length = itr->value.Size();
-        for (int i = 0; i < length; i++)
-        {
-            this->textureFilePaths.push_back(basePath + itr->value[i].GetString());
-        }
-    }
     
+    this->textureFilePaths = {};
     this->soundFilePaths = {};
+    
     return true;
 }

--- a/Classes/Datas/Scene/TitleSceneData.cpp
+++ b/Classes/Datas/Scene/TitleSceneData.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "Datas/Scene/TitleSceneData.h"
+#include "Managers/ResourcesManager.h"
 
 // コンストラクタ
 TitleSceneData::TitleSceneData() {FUNCLOG}
@@ -17,44 +18,24 @@ TitleSceneData::~TitleSceneData() {FUNCLOG}
 // 初期化
 bool TitleSceneData::init()
 {
-	this->textureFilePaths =
-	{
-//        Resource::SpriteFrame::TITLE,
-//        Resource::SpriteFrame::FRAME,
-//        Resource::SpriteFrame::MENU_PANELS,
-//        Resource::SpriteFrame::ICON,
-//        Resource::SpriteFrame::UI,
-//        Resource::SpriteFrame::MAP_OBJECT,
-//        Resource::SpriteFrame::Character::MAGOICHI,
-//        Resource::SpriteFrame::Character::DAIGORO,
-//        Resource::SpriteFrame::Character::DANDAN,
-//        Resource::SpriteFrame::Character::NADESHIKO,
-//        Resource::SpriteFrame::Character::MANAKA,
-//        Resource::SpriteFrame::Character::RANMARU,
-//        Resource::SpriteFrame::Character::SHITSUJI,
-//        Resource::SpriteFrame::Character::YUKI,
-//        Resource::SpriteFrame::Character::FUJIN,
-//        Resource::SpriteFrame::Character::KNIFE,
-//        Resource::SpriteFrame::Character::TAIHO,
-//        Resource::SpriteFrame::Character::T_FUJIN,
-//        Resource::SpriteFrame::Character::W_MANAKA,
-//        Resource::SpriteFrame::Character::W_DANDAN,
-//        Resource::SpriteFrame::Character::O_RANMARU,
-//        Resource::SpriteFrame::Character::S_RANMARU,
-//        Resource::SpriteFrame::Character::D_DAIGORO,
-//        Resource::SpriteFrame::Character::KYOJIN_1,
-//        Resource::SpriteFrame::Character::KYOJIN_2,
-//        Resource::SpriteFrame::Character::KYOJIN_3,
-//        Resource::SpriteFrame::Character::KYOJIN_4,
-	};
+    FUNCLOG
+    string basePath;
+    string jsonPath = ResourcesManager::getInstance()->getCurrentFilePath(Resource::ConfigFiles::PRELOAD_LIST);
+    int length;
+    const rapidjson::Document json = LastSupper::JsonUtils::readJsonCrypted(jsonPath);
+    for (rapidjson::Value::ConstMemberIterator itr = json.MemberBegin(); itr != json.MemberEnd(); itr++)
+    {
+        basePath = ResourcesManager::getInstance()->getCurrentPath() + "/";
+        basePath += itr->name.GetString();
+        basePath += "/";
+        length = itr->value.Size();
+        for (int i = 0; i < length; i++)
+        {
+            this->textureFilePaths.push_back(basePath + itr->value[i].GetString());
+        }
+    }
 	
-	this->soundFilePaths =
-	{
-		//"se/cursorMove.mp3",
-		//"se/back.mp3",
-		//"se/gameStart.mp3",
-		//"se/title-enter.mp3"
-	};
+	this->soundFilePaths = {};
     
 	return true;
 }

--- a/Classes/Layers/Menu/TitleMainMenuLayer.cpp
+++ b/Classes/Layers/Menu/TitleMainMenuLayer.cpp
@@ -201,18 +201,14 @@ void TitleMainMenuLayer::onEnterKeyPressed(int idx)
         {MenuType::TROPHY, this->onTrophySelected},
         {MenuType::SPECIAL_ROOM, this->onSpecialRoomSelected},
 	};
-    if (ConfigDataManager::getInstance()->getMasterConfigData()->isDisplay(MasterConfigData::SPECIAL_ROOM))
-    {
-    }
+    
     MenuType menu {static_cast<MenuType>(idx)};
 	if(!typeMap.count(menu)) return;
     
     // クリアしていない場合
-    if (!PlayerDataManager::getInstance()->getGlobalData()->isCleared())
-    {
+    if (!PlayerDataManager::getInstance()->getGlobalData()->isCleared()) {
         // トロフィー見れない
-        if (menu == MenuType::TROPHY)
-        {
+        if (menu == MenuType::TROPHY) {
             this->prohibitNotification("トロフィーはクリア後に見ることができます");
             return;
         }

--- a/Classes/Layers/TitleSelect/TitleSelectPanel.cpp
+++ b/Classes/Layers/TitleSelect/TitleSelectPanel.cpp
@@ -53,6 +53,7 @@ bool TitleSelectPanel::init(TYPE type)
     Size charaSize { chara->getContentSize() };
     Point charaPos { TYPE_TO_CHARA_POSITION.at(type) };
     chara->setPosition(charaSize.width / 2 + charaPos.x, charaSize.height / 2 + charaPos.y);
+    chara->setColor(Color3B(70, 70, 70));
     this->addChild(chara);
     _chara = chara;
     

--- a/Classes/Managers/ConfigDataManager.cpp
+++ b/Classes/Managers/ConfigDataManager.cpp
@@ -43,10 +43,10 @@ ConfigDataManager::ConfigDataManager()
 {
     FUNCLOG
     this->debugConfigData = DebugConfigData::create();
+    this->masterConfigData = MasterConfigData::create();
     
     CC_SAFE_RETAIN(this->debugConfigData);
     CC_SAFE_RETAIN(this->masterConfigData);
-    CC_SAFE_RETAIN(this->trophyConfigData);
 }
 
 // DebugConfigの取得

--- a/Classes/Models/ConfigData/MasterConfigData.cpp
+++ b/Classes/Models/ConfigData/MasterConfigData.cpp
@@ -22,6 +22,7 @@ const char* MasterConfigData::SPECIAL_ROOM {"special_room"};
 const char* MasterConfigData::OPENING_SCENE {"opening_scene"};
 const char* MasterConfigData::OPENING_VIDEO_FILE {"opening_video_file"};
 const char* MasterConfigData::OPENING_BGM_FILE {"opening_bgm_file"};
+const char* MasterConfigData::TITLE_BGM_FILE {"title_bgm_file"};
 
 // コンストラクタ
 bool MasterConfigData::init()
@@ -41,7 +42,7 @@ bool MasterConfigData::init()
 // 文字列を取得
 string MasterConfigData::getString(const char *targetProperty)
 {
-    if (!this->masterConfig.HasMember(VERSION)) {
+    if (!this->masterConfig.HasMember(targetProperty)) {
         string msg = "MasterConfig property is missing.";
         LastSupper::AssertUtils::fatalAssert(msg);
         return msg;

--- a/Classes/Models/ConfigData/MasterConfigData.h
+++ b/Classes/Models/ConfigData/MasterConfigData.h
@@ -31,6 +31,7 @@ public:
     static const char* OPENING_SCENE;
     static const char* OPENING_VIDEO_FILE;
     static const char* OPENING_BGM_FILE;
+    static const char* TITLE_BGM_FILE;
     
     // instance valiables
 private:

--- a/Classes/Scenes/TitleScene.cpp
+++ b/Classes/Scenes/TitleScene.cpp
@@ -100,8 +100,10 @@ void TitleScene::onExitSelected()
 void TitleScene::onSaveDataSelectCancelled()
 {
     SoundManager::getInstance()->playSE(Resource::SE::BACK);
-	this->saveDataSelector->hide();
-	this->mainMenu->show();
+    runAction(Sequence::createWithTwoActions(
+        CallFunc::create([this](){this->saveDataSelector->hide();}),
+        CallFunc::create([this](){this->mainMenu->show();})
+    ));
 }
 
 // おまけ部屋が選択された時
@@ -152,8 +154,10 @@ void TitleScene::onTrophyListSelected()
 void TitleScene::onTrophyListCanceled()
 {
     SoundManager::getInstance()->playSE(Resource::SE::BACK);
-    this->trophyList->hide();
-    this->mainMenu->show();
+    runAction(Sequence::createWithTwoActions(
+        CallFunc::create([this](){this->trophyList->hide();}),
+        CallFunc::create([this](){this->mainMenu->show();})
+    ));
 }
 
 #pragma mark -

--- a/Classes/Scenes/TitleScene.cpp
+++ b/Classes/Scenes/TitleScene.cpp
@@ -18,6 +18,7 @@
 #include "Layers/Menu/TrophyListLayer.h"
 
 #include "Models/PlayerData/GlobalPlayerData.h"
+#include "Models/ConfigData/MasterConfigData.h"
 
 // コンストラクタ
 TitleScene::TitleScene(){FUNCLOG}
@@ -69,7 +70,7 @@ void TitleScene::onPreloadFinished(LoadingLayer* loadingLayer)
     this->saveDataSelector = saveDataSelector;
     
     // BGM
-    SoundManager::getInstance()->playBGM("title_bgm.mp3", true, 0.7f);
+    SoundManager::getInstance()->playBGM(ConfigDataManager::getInstance()->getMasterConfigData()->getString(MasterConfigData::TITLE_BGM_FILE), true, 0.7f);
 }
 
 // 最初からが選ばれた時

--- a/Classes/Scenes/TitleSelectScene.cpp
+++ b/Classes/Scenes/TitleSelectScene.cpp
@@ -12,6 +12,7 @@
 #include "Datas/Scene/TitleSelectSceneData.h"
 #include "Layers/LoadingLayer.h"
 #include "Layers/TitleSelect/TitleSelectMenuLayer.h"
+#include "Managers/TextureManager.h"
 #include "Managers/ResourcesManager.h"
 
 // コンストラクタ
@@ -40,7 +41,13 @@ void TitleSelectScene::onPreloadFinished(LoadingLayer* loadingLayer)
 // タイトル選択された時
 void TitleSelectScene::onTitleSelected(int titleID)
 {
+    // テクスチャーをクリアする
+    TextureManager::getInstance()->unloadAllTectures();
+
+    // 選択音
     SoundManager::getInstance()->playSE(Resource::SE::TITLE_ENTER);
+    
+    // 選択されたタイトルごとに分岐
     switch (titleID) {
         case 0:
             ResourcesManager::getInstance()->setCurrentPath("6chefs");
@@ -49,6 +56,7 @@ void TitleSelectScene::onTitleSelected(int titleID)
             ResourcesManager::getInstance()->setCurrentPath("6chefs2");
             break;
         default:
+            // 通常はありえない
             ResourcesManager::getInstance()->setCurrentPath("common");
     }
     Director::getInstance()->replaceScene(OpeningScene::create());

--- a/Classes/Scenes/TitleSelectScene.cpp
+++ b/Classes/Scenes/TitleSelectScene.cpp
@@ -35,6 +35,10 @@ void TitleSelectScene::onPreloadFinished(LoadingLayer* loadingLayer)
     TitleSelectMenuLayer* menuLayer { TitleSelectMenuLayer::create(CC_CALLBACK_1(TitleSelectScene::onTitleSelected, this)) };
     this->addChild(menuLayer);
     loadingLayer->onLoadFinished();
+    
+    // BGM
+    SoundManager::getInstance()->playBGM(ConfigDataManager::getInstance()->getMasterConfigData()->getString(MasterConfigData::TITLE_BGM_FILE), true, 0.7f);
+    
     menuLayer->show();
 }
 
@@ -59,5 +63,6 @@ void TitleSelectScene::onTitleSelected(int titleID)
             // 通常はありえない
             ResourcesManager::getInstance()->setCurrentPath("common");
     }
+    SoundManager::getInstance()->stopBGMAll();
     Director::getInstance()->replaceScene(OpeningScene::create());
 }

--- a/Resources/6chefs2/config/MasterConfig.json
+++ b/Resources/6chefs2/config/MasterConfig.json
@@ -8,5 +8,6 @@
         "opening_scene": true
     },
     "opening_video_file": "OPmovie.mp4",
-    "opening_bgm_file": "OPBGM2.mp3"
+    "opening_bgm_file": "OPBGM2.mp3",
+    "title_bgm_file": "title_bgm.mp3"
 }

--- a/Resources/common/config/MasterConfig.json
+++ b/Resources/common/config/MasterConfig.json
@@ -1,5 +1,5 @@
 {
-    "version": "Ver.1.5",
+    "version": "Ver.1.0",
     "copyright": "Copyright (C) 2014-2017 最後の晩餐 All Rights Reserved.",
     "display": {
         "two_icon": false,


### PR DESCRIPTION
 - タイトルごとにSprite読み換えることができるように
 - タイトルでメニュー表示状態から戻るするといきなりタイトルセレクトに戻らないように
 - タイトルとタイトルセレクトでのBGMを設定できるように
 - タイトルセレクターの画像の初期色を暗くしといた

タイトル系のBGMについては
Resourcesの各ディレクトリの`config/MasterConfig.json`で
`"title_bgm_file": "title_bgm.mp3"`のファイル名を書き換えれば変わる