### PR TITLE
動画のメモリ周り見直し

### DIFF
--- a/Classes/UI/Video/VideoTextureCache.cpp
+++ b/Classes/UI/Video/VideoTextureCache.cpp
@@ -138,7 +138,7 @@ Texture2D* VideoTextureCache::addImageWidthData(VideoPic *pic)
 	if(!texture) {
         texture = new Texture2D();
         if( texture && 
-        	texture->initWithImage(pic->_image) ) {
+           texture->initWithImage(pic->_image, Texture2D::Texture2D::PixelFormat::RGB565) ) {
             
             _textures->insert(key, texture);
             texture->release();

--- a/Classes/UI/Video/VideoTextureCache.cpp
+++ b/Classes/UI/Video/VideoTextureCache.cpp
@@ -20,8 +20,8 @@ VideoTextureCache::VideoTextureCache()
 {
     FUNCLOG;
     CCAssert(_sharedTextureCache == NULL, "Attempted to allocate a second instance of a singleton.");
-    _textures = new Map<std::string, Ref *>();
-    _videoDecodes = new Map<std::string, Ref *>();
+    _textures = new Map<std::string, Texture2D *>();
+    _videoDecodes = new Map<std::string, VideoDecode *>();
 }
 
 VideoTextureCache::~VideoTextureCache() { FUNCLOG; }
@@ -106,7 +106,7 @@ void VideoTextureCache::picToTexture(float fd)
 void VideoTextureCache::removeVideo(const char *dir)
 {
     _threadEnd = true;
-    VideoDecode* videoDecode = (VideoDecode*)_videoDecodes->at(dir);
+    VideoDecode* videoDecode = _videoDecodes->at(dir);
     if(videoDecode) {
         unsigned int rcount =  videoDecode->getReferenceCount();
         if(rcount == 1) {
@@ -123,8 +123,7 @@ void VideoTextureCache::removeVideo(const char *dir)
 
 Texture2D* VideoTextureCache::getTexture(int frame)
 {
-    Texture2D * texture = NULL;
-    texture = (Texture2D*)_textures->at(to_string(frame));
+    Texture2D* texture = _textures->at(to_string(frame));
     _delKey = to_string(frame - 5);
 	return texture;
 }
@@ -133,8 +132,7 @@ Texture2D* VideoTextureCache::addImageWidthData(VideoPic *pic)
 {
     string key = to_string(pic->_frame);
     
-    Texture2D * texture = NULL;
-    texture = (Texture2D*)_textures->at(key);
+    Texture2D* texture = _textures->at(key);
 	if(!texture) {
         texture = new Texture2D();
         if( texture && 

--- a/Classes/UI/Video/VideoTextureCache.h
+++ b/Classes/UI/Video/VideoTextureCache.h
@@ -20,8 +20,8 @@ public:
     void picToTexture(float fd);
 
 private:
-    Map<string, Ref *>* _textures;
-    Map<string, Ref *>* _videoDecodes;
+    Map<string, Texture2D *>* _textures;
+    Map<string, VideoDecode *>* _videoDecodes;
     bool _threadEnd = false;
     string _delKey = "";
 };


### PR DESCRIPTION
・Texture2DのPixelFormatをRGB565で指定
・Mapのvalueをキャストして取得するのをやめてもともと型を宣言



